### PR TITLE
Keep original calibration when creating path stack

### DIFF
--- a/src/main/java/tracing/SimpleNeuriteTracer.java
+++ b/src/main/java/tracing/SimpleNeuriteTracer.java
@@ -731,7 +731,9 @@ public class SimpleNeuriteTracer extends ThreePanes
 			newStack.addSlice( null, thisSlice );
 		}
 
-		return new ImagePlus( "Paths rendered in a Stack", newStack );
+		ImagePlus newImp = new ImagePlus( "Paths rendered in a Stack", newStack );
+		newImp.setCalibration(xy.getCalibration());
+		return newImp;
 	}
 
 	/* If non-null, holds a reference to the currently searching thread: */


### PR DESCRIPTION
This fixes the bug described in [this post](http://imagej.1557.x6.nabble.com/Simple-Neurite-Tracer-plugin-analyze-skeleton-tp5012441.html) on the ImageJ mailing list.
