### PR TITLE
Allow import of SWC files with leading white space.

### DIFF
--- a/src/main/java/tracing/PathAndFillManager.java
+++ b/src/main/java/tracing/PathAndFillManager.java
@@ -1665,7 +1665,7 @@ public class PathAndFillManager extends DefaultHandler implements UniverseListen
 		String line;
 		while( (line = br.readLine()) != null ) {
 			Matcher mComment = pComment.matcher(line);
-			line = mComment.replaceAll("$1");
+			line = mComment.replaceAll("$1").trim();
 			Matcher mEmpty = pEmpty.matcher(line);
 			if( mEmpty.matches() )
 				continue;


### PR DESCRIPTION
Some SWC files (from Neuromantic but presumably other software) contain
rows with awkward leading spaces (U+0020 characters). Not sure why, or
what causes them but these files cannot be imported by SNT, as SNT thinks
they are unexpected fields, although the file is perfectly valid.
Also strange is that some of the Neuromorph standardized files also seem
to be affected by this, e.g.,
http://www.neuromorpho.org/dableFiles/martone/CNG%20version/e1cb4a5.CNG.swc
As a precaution, we will get rid of both leading and trailing white spaces,
just in case this ever happens again.
