### PR TITLE
Fix "Unknown type" when importing SWC traces

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,11 @@
 			<properties><id>imagejan</id></properties>
 		</contributor>
 		<contributor>
+			<name>Tiago Ferreira</name>
+			<url>http://imagej.net/User:Tiago</url>
+			<properties><id>tferr</id></properties>
+		</contributor>
+		<contributor>
 			<name>Fethallah Benmansour</name>
 		</contributor>
 	</contributors>

--- a/src/main/java/tracing/PathAndFillManager.java
+++ b/src/main/java/tracing/PathAndFillManager.java
@@ -1787,7 +1787,7 @@ public class PathAndFillManager extends DefaultHandler implements UniverseListen
 					}
 					currentPoint = newCurrentPoint;
 				} else {
-					//currentPath.setSWCType(currentPoint.type); // Assign point type to path
+					currentPath.setSWCType(currentPoint.type); // Assign point type to path
 					currentPoint = null;
 				}
 			}

--- a/src/main/java/tracing/PathAndFillManager.java
+++ b/src/main/java/tracing/PathAndFillManager.java
@@ -1786,8 +1786,10 @@ public class PathAndFillManager extends DefaultHandler implements UniverseListen
 						backtrackTo.add( pointToQueue );
 					}
 					currentPoint = newCurrentPoint;
-				} else
+				} else {
+					//currentPath.setSWCType(currentPoint.type); // Assign point type to path
 					currentPoint = null;
+				}
 			}
 			currentPath.setGuessedTangents( 2 );
 			addPath( currentPath );


### PR DESCRIPTION
When importing SWC files, Simple Neurite Tracer does keep track of the type-property ("axon", "dendrite", "soma", etc) of imported points. However, it discards that information when rendering paths (probably an unintentional overlook in the original code). As a result, all imported paths get assigned the category "unknown". This is quite annoying when using SNT to complete tracings started elsewhere as one as to go back to all the previously traced paths and rename them. This should fix this.

Sorry for not including this in yesterdays' PR #3 , but I've only noticed it now. I am also updating the contributors list in POM, as I've noticed it has been done thoroughly across Fiji projects.
