### PR TITLE
SNT Sholl: Allow filtering of paths based on SWC types

### DIFF
--- a/src/main/java/tracing/Path.java
+++ b/src/main/java/tracing/Path.java
@@ -1652,11 +1652,9 @@ public class Path implements Comparable<Path> {
 
 	double [] precise_x_positions;
 	double [] precise_y_positions;
-        double [] precise_z_positions;
+	double [] precise_z_positions;
 
-	// Going by the meanings of the types given in:
-	//   http://www.soton.ac.uk/~dales/morpho/morpho_doc/
-
+	// http://www.neuronland.org/NLMorphologyConverter/MorphologyFormats/SWC/Spec.html
 	public static final int SWC_UNDEFINED       = 0;
 	public static final int SWC_SOMA            = 1;
 	public static final int SWC_AXON            = 2;
@@ -1665,17 +1663,84 @@ public class Path implements Comparable<Path> {
 	public static final int SWC_FORK_POINT      = 5;
 	public static final int SWC_END_POINT       = 6;
 	public static final int SWC_CUSTOM          = 7;
+	public static final String SWC_UNDEFINED_LABEL       = "undefined";
+	public static final String SWC_SOMA_LABEL            = "soma";
+	public static final String SWC_AXON_LABEL            = "axon";
+	public static final String SWC_DENDRITE_LABEL        = "(basal) dendrite";
+	public static final String SWC_APICAL_DENDRITE_LABEL = "apical dendrite";
+	public static final String SWC_FORK_POINT_LABEL      = "fork point";
+	public static final String SWC_END_POINT_LABEL       = "end point";
+	public static final String SWC_CUSTOM_LABEL          = "custom";
 
-	public static final String [] swcTypeNames = { "undefined",
-						       "soma",
-						       "axon",
-						       "dendrite",
-						       "apical dendrite",
-						       "fork point",
-						       "end point",
-						       "custom" };
+	public static final String [] swcTypeNames = getSWCtypeNamesArray();
+
 
 	int swcType = SWC_UNDEFINED;
+
+	private static String[] getSWCtypeNamesArray() {
+		final ArrayList<String> swcTypes = getSWCtypeNames();
+		return swcTypes.toArray(new String[swcTypes.size()]);
+	}
+
+	public static ArrayList<String> getSWCtypeNames() {
+		final ArrayList<String> swcTypes = new ArrayList<String>();
+		swcTypes.add(SWC_UNDEFINED_LABEL);
+		swcTypes.add(SWC_SOMA_LABEL);
+		swcTypes.add(SWC_AXON_LABEL);
+		swcTypes.add(SWC_DENDRITE_LABEL);
+		swcTypes.add(SWC_APICAL_DENDRITE_LABEL);
+		swcTypes.add(SWC_FORK_POINT_LABEL);
+		swcTypes.add(SWC_END_POINT_LABEL);
+		swcTypes.add(SWC_CUSTOM_LABEL);
+		return swcTypes;
+	}
+
+	public static ArrayList<Integer> getSWCtypes() {
+		final ArrayList<Integer> swcTypes = new ArrayList<Integer>();
+		swcTypes.add(SWC_UNDEFINED);
+		swcTypes.add(SWC_SOMA);
+		swcTypes.add(SWC_AXON);
+		swcTypes.add(SWC_DENDRITE);
+		swcTypes.add(SWC_APICAL_DENDRITE);
+		swcTypes.add(SWC_FORK_POINT);
+		swcTypes.add(SWC_END_POINT);
+		swcTypes.add(SWC_CUSTOM);
+		return swcTypes;
+	}
+
+	public static String getSWCtypeName(final int type) {
+		String typeName;
+		switch (type) {
+		case SWC_UNDEFINED:
+			typeName = SWC_UNDEFINED_LABEL;
+			break;
+		case SWC_SOMA:
+			typeName = SWC_SOMA_LABEL;
+			break;
+		case SWC_AXON:
+			typeName = SWC_AXON_LABEL;
+			break;
+		case SWC_DENDRITE:
+			typeName = SWC_DENDRITE_LABEL;
+			break;
+		case SWC_APICAL_DENDRITE:
+			typeName = SWC_APICAL_DENDRITE_LABEL;
+			break;
+		case SWC_FORK_POINT:
+			typeName = SWC_FORK_POINT_LABEL;
+			break;
+		case SWC_END_POINT:
+			typeName = SWC_END_POINT_LABEL;
+			break;
+		case SWC_CUSTOM:
+			typeName = SWC_CUSTOM_LABEL;
+			break;
+		default:
+			typeName = SWC_UNDEFINED_LABEL;
+			break;
+		}
+		return typeName;
+	}
 
 	public boolean circlesOverlap( double n1x, double n1y, double n1z,
 				       double c1x, double c1y, double c1z,

--- a/src/main/java/tracing/ShollAnalysisDialog.java
+++ b/src/main/java/tracing/ShollAnalysisDialog.java
@@ -94,6 +94,7 @@ import org.jfree.chart.renderer.xy.StandardXYBarPainter;
 import org.jfree.chart.renderer.xy.XYBarRenderer;
 import org.jfree.chart.renderer.xy.XYItemRenderer;
 import org.jfree.chart.renderer.xy.XYLineAndShapeRenderer;
+import org.jfree.chart.title.TextTitle;
 import org.jfree.data.xy.XYSeries;
 import org.jfree.data.xy.XYSeriesCollection;
 import org.w3c.dom.DOMImplementation;
@@ -208,15 +209,38 @@ public class ShollAnalysisDialog extends Dialog implements WindowListener, Actio
 	}
 
 	protected synchronized void updateResults() {
-		ShollResults results = getCurrentResults();
-		resultsPanel.updateFromResults(results);
-		JFreeChart chart = results.createGraph();
-		if( chart == null )
-			return;
-		if( graphFrame == null )
-			graphFrame = new GraphFrame( chart, results.getSuggestedSuffix() );
-		else
-			graphFrame.updateWithNewChart( chart, results.getSuggestedSuffix() );
+		JFreeChart chart;
+
+		if (numberOfAllPaths <= 0) {
+
+			if (graphFrame != null) {
+				chart = graphFrame.chartPanel.getChart();
+				if (chart != null) {
+					chart.setNotify(false);
+					final TextTitle currentitle = chart.getTitle();
+					if (currentitle != null)
+						currentitle.setText("");
+					final XYPlot plot = chart.getXYPlot();
+					if (plot != null)
+						plot.setDataset(null);
+					chart.setNotify(true);
+				}
+			}
+
+		} else { // valid paths to be analyzed
+
+			final ShollResults results = getCurrentResults();
+			resultsPanel.updateFromResults(results);
+			chart = results.createGraph();
+			if (chart == null)
+				return;
+			if (graphFrame == null)
+				graphFrame = new GraphFrame(chart, results.getSuggestedSuffix());
+			else
+				graphFrame.updateWithNewChart(chart, results.getSuggestedSuffix());
+		}
+
+	}
 	}
 
 	public void itemStateChanged( ItemEvent e ) {

--- a/src/main/java/tracing/ShollAnalysisDialog.java
+++ b/src/main/java/tracing/ShollAnalysisDialog.java
@@ -104,6 +104,7 @@ public class ShollAnalysisDialog extends Dialog implements WindowListener, Actio
 	protected CheckboxGroup pathsGroup = new CheckboxGroup();
 	protected Checkbox useAllPathsCheckbox = new Checkbox("Use all paths in analysis?", pathsGroup, false);
 	protected Checkbox useSelectedPathsCheckbox = new Checkbox("Use only selected paths in analysis?", pathsGroup, true);
+	protected ArrayList<String> filteredTypes = Path.getSWCtypeNames();
 	protected Button makeShollImageButton = new Button("Make Sholl image");
 	protected Button drawShollGraphButton = new Button("Draw Graph");
 	protected Button exportDetailAsCSVButton = new Button("Export detailed results as CSV");
@@ -899,7 +900,7 @@ public class ShollAnalysisDialog extends Dialog implements WindowListener, Actio
 
 	ArrayList<ShollPoint> shollPointsAllPaths;
 	ArrayList<ShollPoint> shollPointsSelectedPaths;
-
+	PathAndFillManager shollpafm;
 	ResultsPanel resultsPanel = new ResultsPanel();
 
 	protected boolean twoDimensional;
@@ -922,31 +923,8 @@ public class ShollAnalysisDialog extends Dialog implements WindowListener, Actio
 
 		shollPointsAllPaths = new ArrayList<ShollPoint>();
 		shollPointsSelectedPaths = new ArrayList<ShollPoint>();
-
-		numberOfAllPaths = 0;
-		numberOfSelectedPaths = 0;
-
-		for( Path p : pafm.allPaths ) {
-			boolean selected = p.getSelected();
-			if( p.getUseFitted() ) {
-				p = p.fitted;
-			} else if( p.fittedVersionOf != null )
-				continue;
-			addPathPointsToShollList(p,
-						 x_start,
-						 y_start,
-						 z_start,
-						 shollPointsAllPaths);
-			++ numberOfAllPaths;
-			if( selected ) {
-				addPathPointsToShollList(p,
-							 x_start,
-							 y_start,
-							 z_start,
-							 shollPointsSelectedPaths);
-				++ numberOfSelectedPaths;
-			}
-		}
+		shollpafm = pafm;
+		reloadPaths();
 
 		useAllPathsCheckbox.setLabel("Use all "+numberOfAllPaths+" paths in analysis?");
 		useSelectedPathsCheckbox.setLabel("Use only the "+numberOfSelectedPaths+" selected paths in analysis?");
@@ -1043,6 +1021,34 @@ public class ShollAnalysisDialog extends Dialog implements WindowListener, Actio
 		setVisible(true);
 
 		updateResults();
+	}
+
+	private void reloadPaths() {
+
+		// Reset analysis
+		numberOfAllPaths = 0;
+		numberOfSelectedPaths = 0;
+		shollPointsAllPaths.clear();
+		shollPointsSelectedPaths.clear();
+
+		// load paths considering only those whose type has been chosen by user
+		for (Path p : shollpafm.allPaths) {
+			final boolean selected = p.getSelected();
+			if (p.getUseFitted()) {
+				p = p.fitted;
+			} else if (p.fittedVersionOf != null)
+				continue;
+
+			if (filteredTypes.contains(Path.getSWCtypeName(p.getSWCType()))) {
+				addPathPointsToShollList(p, x_start, y_start, z_start, shollPointsAllPaths);
+				++numberOfAllPaths;
+				if (selected) {
+					addPathPointsToShollList(p, x_start, y_start, z_start, shollPointsSelectedPaths);
+					++numberOfSelectedPaths;
+				}
+			}
+		}
+
 	}
 
 	public class ResultsPanel extends Panel {

--- a/src/main/java/tracing/ShollAnalysisDialog.java
+++ b/src/main/java/tracing/ShollAnalysisDialog.java
@@ -114,6 +114,8 @@ public class ShollAnalysisDialog extends Dialog implements WindowListener, Actio
 	protected JButton swcTypesButton = new JButton("SWC Type Filtering...");
 	protected JPopupMenu swcTypesMenu = new JPopupMenu();
 	protected ArrayList<String> filteredTypes = Path.getSWCtypeNames();
+	protected JLabel filteredTypesWarningLabel = new JLabel();
+
 	protected Button makeShollImageButton = new Button("Make Sholl image");
 	protected Button drawShollGraphButton = new Button("Draw Graph");
 	protected Button exportDetailAsCSVButton = new Button("Export detailed results as CSV");
@@ -213,6 +215,7 @@ public class ShollAnalysisDialog extends Dialog implements WindowListener, Actio
 
 		if (numberOfAllPaths <= 0) {
 
+			makePromptInteractive(false);
 			if (graphFrame != null) {
 				chart = graphFrame.chartPanel.getChart();
 				if (chart != null) {
@@ -229,6 +232,7 @@ public class ShollAnalysisDialog extends Dialog implements WindowListener, Actio
 
 		} else { // valid paths to be analyzed
 
+			makePromptInteractive(true);
 			final ShollResults results = getCurrentResults();
 			resultsPanel.updateFromResults(results);
 			chart = results.createGraph();
@@ -241,6 +245,25 @@ public class ShollAnalysisDialog extends Dialog implements WindowListener, Actio
 		}
 
 	}
+
+	private void makePromptInteractive(boolean interactive) {
+		if (!interactive) {
+			final String noData = " ";
+			resultsPanel.criticalValuesLabel.setText(noData);
+			resultsPanel.dendriteMaximumLabel.setText(noData);
+			resultsPanel.shollsRegressionCoefficientLabel.setText(noData);
+			resultsPanel.shollsRegressionInterceptLabel.setText(noData);
+			filteredTypesWarningLabel.setText("No paths matching current filter(s). Please revise choices...");
+			filteredTypesWarningLabel.setForeground(java.awt.Color.RED);
+		} else {
+			filteredTypesWarningLabel.setText("" + filteredTypes.size() + " type(s) are currently selected");
+			filteredTypesWarningLabel.setForeground(java.awt.Color.DARK_GRAY);
+		}
+		addToResultsTableButton.setEnabled(interactive);
+		drawShollGraphButton.setEnabled(interactive);
+		exportDetailAsCSVButton.setEnabled(interactive);
+		exportSummaryAsCSVButton.setEnabled(interactive);
+		makeShollImageButton.setEnabled(interactive);
 	}
 
 	public void itemStateChanged( ItemEvent e ) {

--- a/src/main/java/tracing/ShollAnalysisDialog.java
+++ b/src/main/java/tracing/ShollAnalysisDialog.java
@@ -494,30 +494,18 @@ public class ShollAnalysisDialog extends Dialog implements WindowListener, Actio
 		}
 		public void addToResultsTable() {
 			ResultsTable rt = Analyzer.getResultsTable();
-			String [] headings = {  };
-			rt.setHeading(0,  "Filename");
-			rt.setHeading(1,  "AllPathsUsed");
-			rt.setHeading(2,  "NumberOfPathsUsed");
-			rt.setHeading(3,  "SphereSeparation");
-			rt.setHeading(4,  "Normalization");
-			rt.setHeading(5,  "Axes");
-			rt.setHeading(6,  "CriticalValue");
-			rt.setHeading(7,  "DendriteMaximum");
-			rt.setHeading(8,  "ShollRegressionCoefficient");
-			rt.setHeading(9,  "RegressionGradient");
-			rt.setHeading(10, "RegressionIntercept");
 			rt.incrementCounter();
-			rt.addLabel("Filename",getOriginalFilename());
-			rt.addValue("AllPathsUsed",useAllPaths?1:0);
-			rt.addValue("NumberOfPathsUsed",numberOfPathsUsed);
-			rt.addValue("SphereSeparation",sphereSeparation);
+			rt.addValue("Filename",getOriginalFilename());
+			rt.addValue("All paths used",String.valueOf(useAllPaths));
+			rt.addValue("Paths used",numberOfPathsUsed);
+			rt.addValue("Sphere separation",sphereSeparation);
 			rt.addValue("Normalization",normalization);
 			rt.addValue("Axes",axes);
-			rt.addValue("CriticalValue",getCriticalValue());
-			rt.addValue("DendriteMaximum",getDendriteMaximum());
-			rt.addValue("ShollRegressionCoefficient",getShollRegressionCoefficient());
-			rt.addValue("RegressionGradient",getRegressionGradient());
-			rt.addValue("RegressionIntercept",getRegressionIntercept());
+			rt.addValue("Max inters. radius",getCriticalValue());
+			rt.addValue("Max inters.",getDendriteMaximum());
+			rt.addValue("Regression coefficient",getShollRegressionCoefficient());
+			rt.addValue("Regression gradient",getRegressionGradient());
+			rt.addValue("Regression intercept",getRegressionIntercept());
 			rt.show("Results");
 		}
 		boolean twoDimensional;
@@ -567,8 +555,8 @@ public class ShollAnalysisDialog extends Dialog implements WindowListener, Actio
 				}
 				// System.out.println("Range starting at: "+Math.sqrt(p.distanceSquared)+" has crossings: "+currentCrossings);
 			}
-			xAxisLabel = "Distance in space from ( "+x_start+", "+y_start+", "+z_start+" )";
-			yAxisLabel = "Number of intersections";
+			xAxisLabel = "Distance from ("+ IJ.d2s(x_start,3) +", "+ IJ.d2s(y_start,3) +", "+IJ.d2s(z_start,3) +")";
+			yAxisLabel = "N. of Intersections";
 			if( sphereSeparation > 0 ) {
 				graphPoints = (int)Math.ceil(Math.sqrt(getMaxDistanceSquared()) / sphereSeparation);
 				x_graph_points = new double[graphPoints];
@@ -611,9 +599,9 @@ public class ShollAnalysisDialog extends Dialog implements WindowListener, Actio
 						y_graph_points[i] /= ((4.0 * Math.PI * x * distanceSquared) / 3.0);
 				}
 				if( twoDimensional )
-					xAxisLabel += " / area enclosed by circle";
+					yAxisLabel = "Inters./Area";
 				else
-					yAxisLabel += " / volume enclosed by sphere";
+					yAxisLabel = "Inters./Volume";
 			}
 
 			SimpleRegression regression = new SimpleRegression();
@@ -691,7 +679,6 @@ public class ShollAnalysisDialog extends Dialog implements WindowListener, Actio
 				xAxis = new LogAxis(xAxisLabel);
 				yAxis = new LogAxis(yAxisLabel);
 			}
-
 
 			xAxis.setRange(minX,maxX);
 			if( axes == AXES_NORMAL )
@@ -807,16 +794,16 @@ public class ShollAnalysisDialog extends Dialog implements WindowListener, Actio
 
 		public void exportSummaryToCSV( File outputFile ) throws IOException {
 			String [] headers = new String[]{ "Filename",
-							  "AllPathsUsed",
-							  "NumberOfPathsUsed",
-							  "SphereSeparation",
-							  "Normlization",
+							  "All paths used",
+							  "Paths used",
+							  "Sphere separation",
+							  "Normalization",
 							  "Axes",
-							  "CriticalValue",
-							  "DendriteMaximum",
-							  "ShollRegressionCoefficient",
-							  "RegressionGradient",
-							  "RegressionIntercept" };
+							  "Max inters. radius",
+							  "Max inters.",
+							  "Regression coefficient",
+							  "Regression gradient",
+							  "Regression intercept" };
 
 			PrintWriter pw = new PrintWriter(new OutputStreamWriter(new FileOutputStream(outputFile.getAbsolutePath()),"UTF-8"));
 			int columns = headers.length;
@@ -1041,10 +1028,13 @@ public class ShollAnalysisDialog extends Dialog implements WindowListener, Actio
 		++ c.gridy;
 		c.gridx = 0;
 		Panel separationPanel = new Panel();
-		separationPanel.add(new Label("Circle / sphere separation (0 for unsampled analysis)"));
+		separationPanel.add(new Label("Radius step size (0 for continuous sampling)"));
 		sampleSeparation.addTextListener(this);
 		separationPanel.add(sampleSeparation);
-		add(separationPanel,c);
+		final String unit = shollpafm.spacing_units;
+		if (unit != null && !unit.equals("unknown") && !unit.equals("pixel"))
+			separationPanel.add(new Label(unit));
+		add(separationPanel, c);
 
 		c.gridx = 0;
 		++ c.gridy;
@@ -1175,12 +1165,12 @@ public class ShollAnalysisDialog extends Dialog implements WindowListener, Actio
 			c.gridx = 0;
 			++ c.gridy;
 			c.gridwidth = 1;
-			add(new Label("Critical value(s):"),c);
+			add(new Label("Max inters. radius: "),c);
 			c.gridx = 1;
 			add(criticalValuesLabel,c);
 			c.gridx = 0;
 			++ c.gridy;
-			add(new Label("Dendrite maximum:"),c);
+			add(new Label("Max inters.: "),c);
 			c.gridx = 1;
 			add(dendriteMaximumLabel,c);
 			// c.gridx = 0;
@@ -1190,12 +1180,12 @@ public class ShollAnalysisDialog extends Dialog implements WindowListener, Actio
 			// add(schoenenRamificationIndexLabel,c);
 			c.gridx = 0;
 			++ c.gridy;
-			add(new Label("Sholl's Regression Coefficient:"),c);
+			add(new Label("Regression coefficient: "),c);
 			c.gridx = 1;
 			add(shollsRegressionCoefficientLabel,c);
 			c.gridx = 0;
 			++ c.gridy;
-			add(new Label("Sholl's Regression Intercept:"),c);
+			add(new Label("Regression intercept: "),c);
 			c.gridx = 1;
 			add(shollsRegressionInterceptLabel,c);
 		}

--- a/src/main/java/tracing/ShollAnalysisDialog.java
+++ b/src/main/java/tracing/ShollAnalysisDialog.java
@@ -108,8 +108,8 @@ public class ShollAnalysisDialog extends Dialog implements WindowListener, Actio
 	protected double x_start, y_start, z_start;
 
 	protected CheckboxGroup pathsGroup = new CheckboxGroup();
-	protected Checkbox useAllPathsCheckbox = new Checkbox("Use all paths in analysis?", pathsGroup, false);
-	protected Checkbox useSelectedPathsCheckbox = new Checkbox("Use only selected paths in analysis?", pathsGroup, true);
+	protected Checkbox useAllPathsCheckbox = new Checkbox("Use all paths in analysis?", pathsGroup, true);
+	protected Checkbox useSelectedPathsCheckbox = new Checkbox("Use only selected paths in analysis?", pathsGroup, false);
 
 	protected JButton swcTypesButton = new JButton("SWC Type Filtering...");
 	protected JPopupMenu swcTypesMenu = new JPopupMenu();

--- a/src/main/java/tracing/ShollAnalysisDialog.java
+++ b/src/main/java/tracing/ShollAnalysisDialog.java
@@ -50,6 +50,7 @@ import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.awt.Label;
 import java.awt.Panel;
+import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.TextField;
 import java.awt.event.ActionEvent;
@@ -73,8 +74,12 @@ import java.util.Collections;
 import java.util.List;
 
 import javax.swing.JButton;
+import javax.swing.JCheckBoxMenuItem;
 import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JMenuItem;
 import javax.swing.JPanel;
+import javax.swing.JPopupMenu;
 
 import org.apache.batik.dom.GenericDOMImplementation;
 import org.apache.batik.svggen.SVGGraphics2D;
@@ -104,6 +109,9 @@ public class ShollAnalysisDialog extends Dialog implements WindowListener, Actio
 	protected CheckboxGroup pathsGroup = new CheckboxGroup();
 	protected Checkbox useAllPathsCheckbox = new Checkbox("Use all paths in analysis?", pathsGroup, false);
 	protected Checkbox useSelectedPathsCheckbox = new Checkbox("Use only selected paths in analysis?", pathsGroup, true);
+
+	protected JButton swcTypesButton = new JButton("SWC Type Filtering...");
+	protected JPopupMenu swcTypesMenu = new JPopupMenu();
 	protected ArrayList<String> filteredTypes = Path.getSWCtypeNames();
 	protected Button makeShollImageButton = new Button("Make Sholl image");
 	protected Button drawShollGraphButton = new Button("Draw Graph");
@@ -949,6 +957,15 @@ public class ShollAnalysisDialog extends Dialog implements WindowListener, Actio
 		useSelectedPathsCheckbox.addItemListener(this);
 
 		++ c.gridy;
+		c.insets = new Insets(0, margin, 0, margin );
+		buildTypeFilteringMenu();
+		add(swcTypesButton,c);
+		++ c.gridy;
+		c.insets = new Insets(0, margin, margin, margin );
+		add(filteredTypesWarningLabel,c);
+		makePromptInteractive(true);
+
+		++ c.gridy;
 		c.insets = new Insets( margin, margin, 0, margin );
 		add(normalAxes,c);
 		normalAxes.addItemListener(this);
@@ -1047,6 +1064,45 @@ public class ShollAnalysisDialog extends Dialog implements WindowListener, Actio
 					++numberOfSelectedPaths;
 				}
 			}
+		}
+
+	}
+
+	private void buildTypeFilteringMenu() {
+		swcTypesButton.addActionListener(new ActionListener() {
+			@Override
+			public void actionPerformed(final ActionEvent e) {
+				if (!swcTypesMenu.isVisible()) {
+					final Point p = swcTypesButton.getLocationOnScreen();
+					swcTypesMenu.setInvoker(swcTypesButton);
+					swcTypesMenu.setLocation((int) p.getX(), (int) p.getY() + swcTypesButton.getHeight());
+					swcTypesMenu.setVisible(true);
+				} else {
+					swcTypesMenu.setVisible(false);
+				}
+			}
+		});
+		for (final String swcType : Path.getSWCtypeNames()) {
+			final JMenuItem mi = new JCheckBoxMenuItem(swcType, true);
+			mi.addActionListener(new ActionListener() {
+				@Override
+				public void actionPerformed(final ActionEvent e) {
+					swcTypesMenu.show(swcTypesButton, 0, swcTypesButton.getHeight());
+				}
+			});
+			mi.addItemListener(new ItemListener() {
+				@Override
+				public void itemStateChanged(final ItemEvent e) {
+					if (filteredTypes.contains(mi.getText()) && !mi.isSelected()) {
+						filteredTypes.remove(mi.getText());
+					} else if (!filteredTypes.contains(mi.getText()) && mi.isSelected()) {
+						filteredTypes.add(mi.getText());
+					}
+					reloadPaths();
+					updateResults();
+				}
+			});
+			swcTypesMenu.add(mi);
 		}
 
 	}

--- a/src/main/java/tracing/ShollAnalysisDialog.java
+++ b/src/main/java/tracing/ShollAnalysisDialog.java
@@ -494,6 +494,8 @@ public class ShollAnalysisDialog extends Dialog implements WindowListener, Actio
 		}
 		public void addToResultsTable() {
 			ResultsTable rt = Analyzer.getResultsTable();
+			if (!Analyzer.resetCounter())
+				return;
 			rt.incrementCounter();
 			rt.addValue("Filename",getOriginalFilename());
 			rt.addValue("All paths used",String.valueOf(useAllPaths));
@@ -697,7 +699,7 @@ public class ShollAnalysisDialog extends Dialog implements WindowListener, Actio
 				barRenderer.setBarPainter(new StandardXYBarPainter());
 				renderer = barRenderer;
 			}
-
+			renderer.setSeriesVisibleInLegend(0, false);
 			XYPlot plot = new XYPlot(
 				data,
 				xAxis,
@@ -1071,10 +1073,12 @@ public class ShollAnalysisDialog extends Dialog implements WindowListener, Actio
 
 		pack();
 
+		updateResults();
+
 		GUI.center(this);
 		setVisible(true);
+		toFront();
 
-		updateResults();
 	}
 
 	private void reloadPaths() {
@@ -1147,11 +1151,11 @@ public class ShollAnalysisDialog extends Dialog implements WindowListener, Actio
 	public class ResultsPanel extends Panel {
 		Label headingLabel = new Label("Results:");
 		String defaultText = "[Not calculated yet]";
-		Label criticalValuesLabel = new Label(defaultText);
-		Label dendriteMaximumLabel = new Label(defaultText);
+		Label criticalValuesLabel = new Label(defaultText, Label.RIGHT);
+		Label dendriteMaximumLabel = new Label(defaultText, Label.RIGHT);
 		// Label schoenenRamificationIndexLabel = new Label(defaultText);
-		Label shollsRegressionCoefficientLabel = new Label(defaultText);
-		Label shollsRegressionInterceptLabel = new Label(defaultText);
+		Label shollsRegressionCoefficientLabel = new Label(defaultText, Label.RIGHT);
+		Label shollsRegressionInterceptLabel = new Label(defaultText, Label.RIGHT);
 		public ResultsPanel() {
 			super();
 			setLayout(new GridBagLayout());
@@ -1191,9 +1195,9 @@ public class ShollAnalysisDialog extends Dialog implements WindowListener, Actio
 		}
 		public void updateFromResults( ShollResults results ) {
 			dendriteMaximumLabel.setText(""+results.getDendriteMaximum());
-			criticalValuesLabel.setText(""+results.getCriticalValue());
-			shollsRegressionCoefficientLabel.setText(""+results.getShollRegressionCoefficient());
-			shollsRegressionInterceptLabel.setText(""+results.getRegressionIntercept());
+			criticalValuesLabel.setText(IJ.d2s(results.getCriticalValue(), 3));
+			shollsRegressionCoefficientLabel.setText(IJ.d2s(results.getShollRegressionCoefficient(), -3));
+			shollsRegressionInterceptLabel.setText(IJ.d2s(results.getRegressionIntercept(), 3));
 		}
 	}
 

--- a/src/main/java/tracing/ShollAnalysisDialog.java
+++ b/src/main/java/tracing/ShollAnalysisDialog.java
@@ -470,6 +470,7 @@ public class ShollAnalysisDialog extends Dialog implements WindowListener, Actio
 		protected String xAxisLabel;
 		protected double regressionGradient = Double.MIN_VALUE;
 		protected double regressionIntercept = Double.MIN_VALUE;
+		protected double regressionRSquare = Double.NaN;
 		String parametersSuffix;
 		public int getDendriteMaximum() {
 			return maxCrossings;
@@ -485,6 +486,9 @@ public class ShollAnalysisDialog extends Dialog implements WindowListener, Actio
 		}
 		public double getRegressionIntercept() {
 			return regressionIntercept;
+		}
+		public double getRegressionRSquare() {
+			return regressionRSquare;
 		}
 		public double getMaxDistanceSquared() {
 			return squaredRangeStarts[n-1];
@@ -635,6 +639,8 @@ public class ShollAnalysisDialog extends Dialog implements WindowListener, Actio
 			}
 			regressionGradient = regression.getSlope();
 			regressionIntercept = regression.getIntercept();
+			// Retrieve r-squared, i.e., the square of the Pearson regression coefficient
+			regressionRSquare = regression.getRSquare();
 
 			if( maxY == Double.MIN_VALUE )
 				throw new RuntimeException("[BUG] Somehow there were no valid points found");
@@ -907,6 +913,7 @@ public class ShollAnalysisDialog extends Dialog implements WindowListener, Actio
 			}
 			pw.close();
 		}
+
 	}
 
 	public static class ShollPoint implements Comparable<ShollPoint> {
@@ -1156,6 +1163,7 @@ public class ShollAnalysisDialog extends Dialog implements WindowListener, Actio
 		// Label schoenenRamificationIndexLabel = new Label(defaultText);
 		Label shollsRegressionCoefficientLabel = new Label(defaultText, Label.RIGHT);
 		Label shollsRegressionInterceptLabel = new Label(defaultText, Label.RIGHT);
+		Label shollsRegressionRSquared = new Label(defaultText, Label.RIGHT);
 		public ResultsPanel() {
 			super();
 			setLayout(new GridBagLayout());
@@ -1192,12 +1200,18 @@ public class ShollAnalysisDialog extends Dialog implements WindowListener, Actio
 			add(new Label("Regression intercept: "),c);
 			c.gridx = 1;
 			add(shollsRegressionInterceptLabel,c);
+			c.gridx = 0;
+			++ c.gridy;
+			add(new Label("Regression R2: "),c);
+			c.gridx = 1;
+			add(shollsRegressionRSquared,c);
 		}
 		public void updateFromResults( ShollResults results ) {
 			dendriteMaximumLabel.setText(""+results.getDendriteMaximum());
 			criticalValuesLabel.setText(IJ.d2s(results.getCriticalValue(), 3));
 			shollsRegressionCoefficientLabel.setText(IJ.d2s(results.getShollRegressionCoefficient(), -3));
 			shollsRegressionInterceptLabel.setText(IJ.d2s(results.getRegressionIntercept(), 3));
+			shollsRegressionRSquared.setText(IJ.d2s(results.getRegressionRSquare(), 3));
 		}
 	}
 

--- a/src/main/java/tracing/SimpleNeuriteTracer.java
+++ b/src/main/java/tracing/SimpleNeuriteTracer.java
@@ -392,7 +392,7 @@ public class SimpleNeuriteTracer extends ThreePanes
 
 				YesNoCancelDialog d = new YesNoCancelDialog( IJ.getInstance(),
 									     "Confirm",
-									     "Load the default labels file? ("+path+")" );
+									     "Load the default labels file?\n("+path+")" );
 
 				if( d.yesPressed() ) {
 
@@ -453,7 +453,7 @@ public class SimpleNeuriteTracer extends ThreePanes
 
 					YesNoCancelDialog d = new YesNoCancelDialog( IJ.getInstance(),
 										     "Confirm",
-										     "Load the default traces file? ("+path+")" );
+										     "Load the default traces file?\n("+path+")" );
 
 					if( d.yesPressed() ) {
 


### PR DESCRIPTION
There are [multiple ways](http://neuromorpho.org/SomaFormat.html) of tracing a soma. If one uses multiple paths to trace it and performs Sholl on the traced structure, SNT will consider such paths as independent objects, which is unexpected. A way around it is to select all paths, then deselect manually the paths one is not interested before generating the Sholl profile. This may not be practical for large reconstructions. The issue is discussed in the [forum](http://forum.imagej.net/t/initial-values-of-sholl-analysis/2895) and fiji/Simple_Neurite_Tracer#5. 

This PR does the following:
-  Adds a new option in prompt to exclude paths tagged by SWC types, so that one can perform Sholl only on "Axons", "Dendrites", "Both but not the soma", etc... This requires paths to be previously tagged using the _SWC Type_ menu. This means one can also obtain profiles from  cherry picked structures (such as branch points), which was not possible before.
- Puts SNT and the [tferr/ASA](https://github.com/tferr/ASA) plugin on the same page. SNT did not use the conventions in http://imagej.net/Sholl, and that was always a source of confusion for users[1]
- While at it, we corrected typos and some minor issues.

I've tried to split the changes into commits. Hopefully it will be easy to review. SNT is not macro recordable, and the above changes affect only the GUI for Sholl Analysis, so it should not affect any projects depending on SNT.

@ctrueden, I guess a new SNT version should be released once this merged? I could upload the jar from Jenkins to the Java8 update site, but I cannot create a new GitHub release on this repo directly.

[1] BTW, the proper way to ensure this sort of disparities would be to pass all the calculations to [tferr/ASA](https://github.com/tferr/ASA), which is now quite mature. In retrospect, I should have worked on this long ago. I will try to find the time to work on it later on.
