### PR TITLE
Overlay annotations, ROI export and ESWC import

### DIFF
--- a/src/main/java/tracing/InteractiveTracerCanvas.java
+++ b/src/main/java/tracing/InteractiveTracerCanvas.java
@@ -184,7 +184,8 @@ public class InteractiveTracerCanvas extends TracerCanvas {
 		int currentState = tracerPlugin.resultsDialog.getState();
 
 		if( currentState == NeuriteTracerResultsDialog.LOADING ||
-		    currentState == NeuriteTracerResultsDialog.SAVING ) {
+		    currentState == NeuriteTracerResultsDialog.SAVING ||
+		    currentState == NeuriteTracerResultsDialog.IMAGE_CLOSED) {
 
 			// Do nothing
 

--- a/src/main/java/tracing/NeuriteTracerResultsDialog.java
+++ b/src/main/java/tracing/NeuriteTracerResultsDialog.java
@@ -53,6 +53,7 @@ import java.awt.Graphics;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
+import java.awt.Point;
 import java.awt.TextField;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -116,6 +117,8 @@ public class NeuriteTracerResultsDialog
 	protected JCheckBoxMenuItem xyCanvasMenuItem;
 	protected JCheckBoxMenuItem zyCanvasMenuItem;
 	protected JCheckBoxMenuItem xzCanvasMenuItem;
+	protected JMenuItem arrangeWindowsMenuItem;
+
 
 	// These are the states that the UI can be in:
 
@@ -818,6 +821,10 @@ public class NeuriteTracerResultsDialog
 		xzCanvasMenuItem.setEnabled(!plugin.getSinglePane());
 		xzCanvasMenuItem.addItemListener(this);
 		viewMenu.add(xzCanvasMenuItem);
+		viewMenu.addSeparator();
+		arrangeWindowsMenuItem = new JMenuItem("Arrange planes");
+		arrangeWindowsMenuItem.addActionListener(this);
+		viewMenu.add(arrangeWindowsMenuItem);
 
 		setJMenuBar(menuBar);
 
@@ -1466,7 +1473,30 @@ public class NeuriteTracerResultsDialog
 
 			if( ! ignoreColorImageChoiceEvents )
 				checkForColorImageChange();
+
+		} else if (source == arrangeWindowsMenuItem) {
+			arrangeWindows();
 		}
+	}
+
+	private void arrangeWindows() {
+		final StackWindow xy_window = plugin.getWindow(ThreePanes.XY_PLANE);
+		if (xy_window == null)
+			return;
+		if (!plugin.getSinglePane()) {
+			final Point loc = xy_window.getLocation();
+			final StackWindow zy_window = plugin.getWindow(ThreePanes.ZY_PLANE);
+			final StackWindow xz_window = plugin.getWindow(ThreePanes.XZ_PLANE);
+			if (zy_window != null) {
+				zy_window.setLocation(loc.x + xy_window.getWidth(), loc.y);
+				zy_window.toFront();
+			}
+			if (xz_window != null) {
+				xz_window.setLocation(loc.x, loc.y + xy_window.getHeight());
+				xz_window.toFront();
+			}
+		}
+		xy_window.toFront();
 	}
 
 	private void toggleWindowVisibility(final int pane, final JCheckBoxMenuItem menuItem, final boolean setVisible) {

--- a/src/main/java/tracing/NeuriteTracerResultsDialog.java
+++ b/src/main/java/tracing/NeuriteTracerResultsDialog.java
@@ -716,7 +716,7 @@ public class NeuriteTracerResultsDialog
 
 		menuBar.add(helpMenu());
 
-		loadMenuItem = new JMenuItem("Load traces / SWC file...");
+		loadMenuItem = new JMenuItem("Load traces / (e)SWC file...");
 		loadMenuItem.addActionListener(this);
 		fileMenu.add(loadMenuItem);
 

--- a/src/main/java/tracing/NeuriteTracerResultsDialog.java
+++ b/src/main/java/tracing/NeuriteTracerResultsDialog.java
@@ -28,6 +28,7 @@
 package tracing;
 
 import sc.fiji.skeletonize3D.Skeletonize3D_;
+import sholl.Sholl_Analysis;
 import stacks.ThreePanes;
 import features.SigmaPalette;
 import ij.IJ;
@@ -36,6 +37,7 @@ import ij.ImagePlus;
 import ij.Prefs;
 import ij.WindowManager;
 import ij.gui.GenericDialog;
+import ij.gui.HTMLDialog;
 import ij.gui.StackWindow;
 import ij.gui.WaitForUserDialog;
 import ij.gui.YesNoCancelDialog;
@@ -786,7 +788,7 @@ public class NeuriteTracerResultsDialog
 		analysisMenu.add(makeLineStackMenuItem);
 
 		analysisMenu.addSeparator();
-		addPathsToOverlayMenuItem = new JMenuItem("Add paths to canvas(es) overlay...");
+		addPathsToOverlayMenuItem = new JMenuItem("Add paths to overlay...");
 		addPathsToOverlayMenuItem.addActionListener(this);
 		analysisMenu.add(addPathsToOverlayMenuItem);
 		addPathsToManagerMenuItem = new JMenuItem("Export paths to ROI Manager");
@@ -794,6 +796,8 @@ public class NeuriteTracerResultsDialog
 		analysisMenu.add(addPathsToManagerMenuItem);
 		analysisMenu.addSeparator();
 
+		analysisMenu.add(shollAnalysisHelpMenuItem());
+		analysisMenu.addSeparator();
 		exportCSVMenuItemAgain = new JMenuItem("Export as CSV...");
 		exportCSVMenuItemAgain.addActionListener(this);
 		analysisMenu.add(exportCSVMenuItemAgain);
@@ -810,19 +814,20 @@ public class NeuriteTracerResultsDialog
 		viewMenu.add(drawDiametersXYMenuItem);
 
 		viewMenu.addSeparator();
-		xyCanvasMenuItem = new JCheckBoxMenuItem("Hide XY pane");
+		xyCanvasMenuItem = new JCheckBoxMenuItem("Hide XY plane");
 		xyCanvasMenuItem.addItemListener(this);
 		viewMenu.add(xyCanvasMenuItem);
-		zyCanvasMenuItem = new JCheckBoxMenuItem("Hide ZY pane");
+		zyCanvasMenuItem = new JCheckBoxMenuItem("Hide ZY plane");
 		zyCanvasMenuItem.setEnabled(!plugin.getSinglePane());
 		zyCanvasMenuItem.addItemListener(this);
 		viewMenu.add(zyCanvasMenuItem);
-		xzCanvasMenuItem = new JCheckBoxMenuItem("Hide XZ pane");
+		xzCanvasMenuItem = new JCheckBoxMenuItem("Hide XZ plane");
 		xzCanvasMenuItem.setEnabled(!plugin.getSinglePane());
 		xzCanvasMenuItem.addItemListener(this);
 		viewMenu.add(xzCanvasMenuItem);
 		viewMenu.addSeparator();
 		arrangeWindowsMenuItem = new JMenuItem("Arrange planes");
+		arrangeWindowsMenuItem.setEnabled(!plugin.getSinglePane());
 		arrangeWindowsMenuItem.addActionListener(this);
 		viewMenu.add(arrangeWindowsMenuItem);
 
@@ -1696,29 +1701,7 @@ public class NeuriteTracerResultsDialog
 		mi = menuItemTrigerringURL("List of shortcuts", URL + ":_Key_Shortcuts");
 		helpMenu.add(mi);
 		helpMenu.addSeparator();
-		mi = menuItemTrigerringURL("Sholl analysis: Online help", URL + ":_Sholl_analysis");
-		helpMenu.add(mi);
-		mi = new JMenuItem("Sholl analysis: Offline help");
-		mi.addActionListener(new ActionListener() {
-			@Override
-			public void actionPerformed(final ActionEvent e) {
-				final Thread newThread = new Thread(new Runnable() {
-					@Override
-					public void run() {
-						String modKey = IJ.isMacOSX() ? "Alt" : "Ctrl";
-						modKey += "+Shift";
-						final String instructions = "To manually select the center of analysis:\n"
-								+ "    1. Mouse over the path of interest and press \"G\" to activate it\n"
-								+ "    2. Press \"" + modKey + "\" to select a point along the path\n"
-								+ "    3. Press \"" + modKey + "+A\" to initiate Sholl analysis\n \n"
-								+ "For batch processing run \"Sholl Analysis (Tracings)...\".";
-						final WaitForUserDialog wd = new WaitForUserDialog("Sholl Analysis Cheat Sheet", instructions);
-						wd.show();
-					}
-				});
-				newThread.start();
-			}
-		});
+		mi = menuItemTrigerringURL("Sholl analysis walkthrough", URL + ":_Sholl_analysis");
 		helpMenu.add(mi);
 		helpMenu.addSeparator();
 		mi = menuItemTrigerringURL("Ask a question", "http://forum.imagej.net");
@@ -1727,6 +1710,42 @@ public class NeuriteTracerResultsDialog
 		mi = menuItemTrigerringURL("Citing SNT...", URL + "#Citing_Simple_Neurite_Tracer");
 		helpMenu.add(mi);
 		return helpMenu;
+	}
+
+	private JMenuItem shollAnalysisHelpMenuItem() {
+		JMenuItem mi;
+		mi = new JMenuItem("Sholl Analysis...");
+		mi.addActionListener(new ActionListener() {
+			@Override
+			public void actionPerformed(final ActionEvent e) {
+				final Thread newThread = new Thread(new Runnable() {
+					@Override
+					public void run() {
+						String modKey = IJ.isMacOSX() ? "Alt" : "Ctrl";
+						modKey += "+Shift";
+						final String url1 = Sholl_Analysis.URL + "#Analysis_of_Traced_Cells";
+						final String url2 = "http://imagej.net/Simple_Neurite_Tracer/:_Sholl_analysis";
+						final StringBuilder sb = new StringBuilder();
+						sb.append("<html>");
+						sb.append("<div WIDTH=390>");
+						sb.append("To initiate <a href='").append(Sholl_Analysis.URL).append("'>Sholl Analysis</a>, ");
+						sb.append("you must first select a focal point:");
+						sb.append("<ol>");
+						sb.append("<li>Mouse over the path of interest. Press \"G\" to activate it</li>");
+						sb.append("<li>Press \"").append(modKey).append("\" to select a point along the path</li>");
+						sb.append("<li>Press \"").append(modKey).append("+A\" to start analysis</li>");
+						sb.append("</ol>");
+						sb.append("A detailed walkthrough is also <a href='").append(url2)
+								.append("'>available online</a>. ");
+						sb.append("For batch processing, run <a href='").append(url1)
+								.append("'>Analyze>Sholl>Sholl Analysis (Tracings)...</a>. ");
+						new HTMLDialog("Sholl Analysis How-to", sb.toString(), false);
+					}
+				});
+				newThread.start();
+			}
+		});
+		return mi;
 	}
 
 	public static JMenuItem menuItemTrigerringURL(final String label, final String URL) {

--- a/src/main/java/tracing/NeuriteTracerResultsDialog.java
+++ b/src/main/java/tracing/NeuriteTracerResultsDialog.java
@@ -1105,7 +1105,7 @@ public class NeuriteTracerResultsDialog
 			plugin.uploadTracings();
 		} else if( source == fetchButton ) {
 			plugin.getTracings( true );
-		} else */ if( source == saveMenuItem ) {
+		} else */ if( source == saveMenuItem  && !noPathsError()) {
 
 			FileInfo info = plugin.file_info;
 			SaveDialog sd;
@@ -1179,7 +1179,7 @@ public class NeuriteTracerResultsDialog
 			plugin.loadTracings();
 			changeState( preLoadingState );
 
-		} else if( source == exportAllSWCMenuItem ) {
+		} else if( source == exportAllSWCMenuItem  && !noPathsError()) {
 
 			FileInfo info = plugin.file_info;
 			SaveDialog sd;
@@ -1216,7 +1216,7 @@ public class NeuriteTracerResultsDialog
 				return;
 			pathAndFillManager.exportAllAsSWC( savePath );
 
-		} else if( source == exportCSVMenuItem || source == exportCSVMenuItemAgain ) {
+		} else if( source == exportCSVMenuItem || source == exportCSVMenuItemAgain  && !noPathsError()) {
 
 			FileInfo info = plugin.file_info;
 			SaveDialog sd;

--- a/src/main/java/tracing/NeuriteTracerResultsDialog.java
+++ b/src/main/java/tracing/NeuriteTracerResultsDialog.java
@@ -1216,7 +1216,7 @@ public class NeuriteTracerResultsDialog
 				return;
 			pathAndFillManager.exportAllAsSWC( savePath );
 
-		} else if( source == exportCSVMenuItem || source == exportCSVMenuItemAgain  && !noPathsError()) {
+		} else if( (source == exportCSVMenuItem || source == exportCSVMenuItemAgain)  && !noPathsError()) {
 
 			FileInfo info = plugin.file_info;
 			SaveDialog sd;

--- a/src/main/java/tracing/PathAndFillManager.java
+++ b/src/main/java/tracing/PathAndFillManager.java
@@ -1670,7 +1670,7 @@ public class PathAndFillManager extends DefaultHandler implements UniverseListen
 			if( mEmpty.matches() )
 				continue;
 			String [] fields = line.split("\\s+");
-			if( fields.length != 7 ) {
+			if( fields.length < 7 ) {
 				IJ.error("Wrong number of fields ("+fields.length+") in line: "+line);
 				return false;
 			}

--- a/src/main/java/tracing/PathWindow.java
+++ b/src/main/java/tracing/PathWindow.java
@@ -32,6 +32,8 @@ import ij.gui.GenericDialog;
 import ij.io.SaveDialog;
 
 import java.awt.BorderLayout;
+import java.awt.Font;
+import java.awt.Insets;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseAdapter;
@@ -61,6 +63,7 @@ import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
 import javax.swing.JTree;
 import javax.swing.SwingUtilities;
+import javax.swing.border.EmptyBorder;
 import javax.swing.event.TreeSelectionEvent;
 import javax.swing.event.TreeSelectionListener;
 import javax.swing.tree.DefaultMutableTreeNode;
@@ -525,7 +528,7 @@ public class PathWindow extends JFrame implements PathAndFillListener, TreeSelec
 		this.pathAndFillManager = pathAndFillManager;
 		this.plugin = plugin;
 
-		setBounds(x,y,700,300);
+		setBounds(x,y,600,240);
 		root = new DefaultMutableTreeNode("All Paths");
 		tree = new HelpfulJTree(root);
 		// tree.setRootVisible(false);
@@ -535,6 +538,7 @@ public class PathWindow extends JFrame implements PathAndFillListener, TreeSelec
 		add(scrollPane, BorderLayout.CENTER);
 
 		buttonPanel = new JPanel();
+		buttonPanel.setBorder(new EmptyBorder(0, 0, 0, 0));
 
 		add(buttonPanel, BorderLayout.PAGE_END);
 
@@ -577,13 +581,12 @@ public class PathWindow extends JFrame implements PathAndFillListener, TreeSelec
 		popup.add(swcTypeMenu);
 
 		// Create all the menu items:
-
-		renameButton = new JButton("Rename");
-		fitVolumeButton = new JButton("Fit Volume");
-		fillOutButton = new JButton("Fill Out");
-		makePrimaryButton = new JButton("Make Primary");
-		deleteButton = new JButton("Delete");
-		exportAsSWCButton = new JButton("Export as SWC");
+		renameButton = smallButton("Rename");
+		fitVolumeButton = smallButton("Fit Volume");
+		fillOutButton = smallButton("Fill Out");
+		makePrimaryButton = smallButton("Make Primary");
+		deleteButton = smallButton("Delete");
+		exportAsSWCButton = smallButton("Export as SWC");
 
 		buttonPanel.add(renameButton);
 		buttonPanel.add(fitVolumeButton);
@@ -614,6 +617,17 @@ public class PathWindow extends JFrame implements PathAndFillListener, TreeSelec
 			}
 		};
 		tree.addMouseListener(ml);
+	}
+
+	private JButton smallButton(final String text) {
+		final double SCALE = .85;
+		final JButton button = new JButton(text);
+		final Font font = button.getFont();
+		button.setFont(font.deriveFont((float) (font.getSize() * SCALE)));
+		final Insets insets = button.getMargin();
+		button.setMargin(new Insets((int) (insets.top * SCALE), (int) (insets.left * SCALE),
+				(int) (insets.bottom * SCALE), (int) (insets.right * SCALE)));
+		return button;
 	}
 
 	protected void showPopup(MouseEvent me) {

--- a/src/main/java/tracing/ShollAnalysisPlugin.java
+++ b/src/main/java/tracing/ShollAnalysisPlugin.java
@@ -106,7 +106,7 @@ public class ShollAnalysisPlugin implements PlugIn, DialogListener {
 
 		imp = (impRequired) ? IJ.openImage(imgPath) : null;
 		if (impRequired && imp == null || !validTracesFile(new File(tracesPath))) {
-			IJ.error("Invalid image or invalid Traces/SWC file\n \n" + imgPath + "\n" + tracesPath);
+			IJ.error("Invalid image or invalid Traces/(e)SWC file\n \n" + imgPath + "\n" + tracesPath);
 			return;
 		}
 
@@ -254,7 +254,7 @@ public class ShollAnalysisPlugin implements PlugIn, DialogListener {
 			guessInitialPaths();
 
 		gd = new EnhancedGenericDialog("Sholll Analysis (Tracings)...");
-		gd.addFileField("Traces/SWC file", tracesPath, 32);
+		gd.addFileField("Traces/(e)SWC file", tracesPath, 32);
 		gd.addFileField("Image file", imgPath, 32);
 		gd.setInsets(0, 40, 20);
 		gd.addCheckbox("Load tracings without image", !impRequired);
@@ -365,7 +365,7 @@ public class ShollAnalysisPlugin implements PlugIn, DialogListener {
 		}
 		if (!validTracesFile(new File(tracesPath))) {
 			enableOK = false;
-			warning += "Not a valid .traces/.swc file";
+			warning += "Not a valid .traces/.(e)swc file";
 		}
 		if (!warning.isEmpty()) {
 			infoMsg.setForeground(Utils.warningColor());
@@ -426,7 +426,7 @@ public class ShollAnalysisPlugin implements PlugIn, DialogListener {
 	}
 
 	private boolean tracingsFile(final File file) {
-		final String[] tracingsExts = new String[] { ".traces", ".swc" };
+		final String[] tracingsExts = new String[] { ".traces", ".swc", ".eswc" };
 		for (final String ext : tracingsExts)
 			if (file.getName().toLowerCase().endsWith(ext))
 				return true;

--- a/src/main/java/tracing/SimpleNeuriteTracer.java
+++ b/src/main/java/tracing/SimpleNeuriteTracer.java
@@ -1701,6 +1701,8 @@ public class SimpleNeuriteTracer extends ThreePanes
 			allImages.add(zy);
 		}
 		for( ImagePlus imagePlus : allImages ) {
+			if (imagePlus == null || imagePlus.getImageStackSize() == 1)
+				continue;
 			Overlay overlayList = imagePlus.getOverlay();
 			if( show ) {
 

--- a/src/main/java/tracing/SimpleNeuriteTracer.java
+++ b/src/main/java/tracing/SimpleNeuriteTracer.java
@@ -41,6 +41,7 @@ import ij.Prefs;
 import ij.gui.ImageRoi;
 import ij.gui.Overlay;
 import ij.gui.Roi;
+import ij.gui.StackWindow;
 import ij.gui.YesNoCancelDialog;
 import ij.io.FileInfo;
 import ij.io.OpenDialog;
@@ -58,6 +59,7 @@ import java.io.File;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -1668,6 +1670,28 @@ public class SimpleNeuriteTracer extends ThreePanes
 
 	public boolean getDrawDiametersXY() {
 		return drawDiametersXY;
+	}
+
+	@Override
+	public void closeAndReset() {
+		// Dispose xz/zy windows unless the user stored some annotations (ROIs)
+		// on the image overlay
+		if (!single_pane) {
+			final List<ImagePlus> zyxz = Arrays.asList(xz, zy);
+			for (final ImagePlus imp : zyxz) {
+				final Overlay overlay = imp.getOverlay();
+				removeMIPfromOverlay(overlay);
+				if (imp.getOverlay().size() == 0)
+					imp.close();
+			}
+		}
+		// Restore main view
+		final Overlay overlay = (xy == null) ? null : xy.getOverlay();
+		if (original_xy_canvas != null && xy != null && xy.getImage() != null) {
+			xy_window = new StackWindow(xy, original_xy_canvas);
+			removeMIPfromOverlay(overlay);
+			xy_window.getImagePlus().setOverlay(overlay);
+		}
 	}
 
 }

--- a/src/main/java/tracing/SimpleNeuriteTracer.java
+++ b/src/main/java/tracing/SimpleNeuriteTracer.java
@@ -1755,15 +1755,16 @@ public class SimpleNeuriteTracer extends ThreePanes
 
 	@Override
 	public void closeAndReset() {
-		// Dispose xz/zy windows unless the user stored some annotations (ROIs)
-		// on the image overlay
+		// Dispose xz/zy images unless the user stored some annotations (ROIs)
+		// on the image overlay or modified them somehow. In that case, restore
+		// them to the user
 		if (!single_pane) {
-			final ImagePlus[] impPanes= {xz, zy};
-			final StackWindow[] winPanes= {xz_window, zy_window};
+			final ImagePlus[] impPanes = { xz, zy };
+			final StackWindow[] winPanes = { xz_window, zy_window };
 			for (int i = 0; i < impPanes.length; ++i) {
 				final Overlay overlay = impPanes[i].getOverlay();
 				removeMIPfromOverlay(overlay);
-				if (overlay == null || impPanes[i].getOverlay().size() == 0)
+				if (!impPanes[i].changes && (overlay == null || impPanes[i].getOverlay().size() == 0))
 					impPanes[i].close();
 				else {
 					winPanes[i] = new StackWindow(impPanes[i]);

--- a/src/main/java/tracing/SimpleNeuriteTracer.java
+++ b/src/main/java/tracing/SimpleNeuriteTracer.java
@@ -1758,12 +1758,18 @@ public class SimpleNeuriteTracer extends ThreePanes
 		// Dispose xz/zy windows unless the user stored some annotations (ROIs)
 		// on the image overlay
 		if (!single_pane) {
-			final List<ImagePlus> zyxz = Arrays.asList(xz, zy);
-			for (final ImagePlus imp : zyxz) {
-				final Overlay overlay = imp.getOverlay();
+			final ImagePlus[] impPanes= {xz, zy};
+			final StackWindow[] winPanes= {xz_window, zy_window};
+			for (int i = 0; i < impPanes.length; ++i) {
+				final Overlay overlay = impPanes[i].getOverlay();
 				removeMIPfromOverlay(overlay);
-				if (imp.getOverlay().size() == 0)
-					imp.close();
+				if (overlay == null || impPanes[i].getOverlay().size() == 0)
+					impPanes[i].close();
+				else {
+					winPanes[i] = new StackWindow(impPanes[i]);
+					removeMIPfromOverlay(overlay);
+					impPanes[i].setOverlay(overlay);
+				}
 			}
 		}
 		// Restore main view
@@ -1771,7 +1777,7 @@ public class SimpleNeuriteTracer extends ThreePanes
 		if (original_xy_canvas != null && xy != null && xy.getImage() != null) {
 			xy_window = new StackWindow(xy, original_xy_canvas);
 			removeMIPfromOverlay(overlay);
-			xy_window.getImagePlus().setOverlay(overlay);
+			xy.setOverlay(overlay);
 		}
 	}
 

--- a/src/main/java/tracing/SimpleNeuriteTracer.java
+++ b/src/main/java/tracing/SimpleNeuriteTracer.java
@@ -1522,6 +1522,23 @@ public class SimpleNeuriteTracer extends ThreePanes
 		}
 	}
 
+	public StackWindow getWindow(final int plane) {
+		switch (plane) {
+		case ThreePanes.XY_PLANE:
+			return xy_window;
+		case ThreePanes.XZ_PLANE:
+			return (single_pane) ? null : xz_window;
+		case ThreePanes.ZY_PLANE:
+			return (single_pane) ? null : zy_window;
+		default:
+			return null;
+		}
+	}
+
+	public boolean getSinglePane() {
+		return single_pane;
+	}
+
 	public boolean getShowOnlySelectedPaths() {
 		return showOnlySelectedPaths;
 	}

--- a/src/main/java/tracing/SimpleNeuriteTracer.java
+++ b/src/main/java/tracing/SimpleNeuriteTracer.java
@@ -1610,6 +1610,7 @@ public class SimpleNeuriteTracer extends ThreePanes
 	}
 
 	public static final int OVERLAY_OPACITY_PERCENT = 20;
+	private static final String OVERLAY_IDENTIFIER = "SNT-MIP-OVERLAY";
 
 	public void showMIPOverlays(boolean show) {
 		ArrayList<ImagePlus> allImages = new ArrayList<ImagePlus>();
@@ -1619,6 +1620,7 @@ public class SimpleNeuriteTracer extends ThreePanes
 			allImages.add(zy);
 		}
 		for( ImagePlus imagePlus : allImages ) {
+			Overlay overlayList = imagePlus.getOverlay();
 			if( show ) {
 
 				// Create a MIP project of the stack:
@@ -1631,16 +1633,27 @@ public class SimpleNeuriteTracer extends ThreePanes
 				// Add display it as an overlay.
 				// (This logic is taken from OverlayCommands.)
 				Roi roi = new ImageRoi(0, 0, overlay.getProcessor());
-				roi.setName(overlay.getShortTitle());
+				roi.setName(OVERLAY_IDENTIFIER);
 				((ImageRoi)roi).setOpacity(OVERLAY_OPACITY_PERCENT/100.0);
-				Overlay overlayList = imagePlus.getOverlay();
 				if (overlayList==null)
 					overlayList = new Overlay();
 				overlayList.add(roi);
-				imagePlus.setOverlay(overlayList);
 
 			} else {
-				imagePlus.setOverlay(null);
+				removeMIPfromOverlay(overlayList);
+			}
+			imagePlus.setOverlay(overlayList);
+		}
+	}
+
+	private void removeMIPfromOverlay(Overlay overlay) {
+		if (overlay != null && overlay.size() > 0) {
+			for (int i = overlay.size() - 1; i >= 0; i--) {
+				final String roiName = overlay.get(i).getName();
+				if (roiName != null && roiName.equals(OVERLAY_IDENTIFIER)) {
+					overlay.remove(i);
+					return;
+				}
 			}
 		}
 	}

--- a/src/main/java/tracing/SimpleNeuriteTracer.java
+++ b/src/main/java/tracing/SimpleNeuriteTracer.java
@@ -489,7 +489,7 @@ public class SimpleNeuriteTracer extends ThreePanes
 
 		OpenDialog od;
 
-		od = new OpenDialog("Select .traces or .swc file...",
+		od = new OpenDialog("Select .traces or .(e)swc file...",
 				    directory,
 				    null );
 

--- a/src/main/java/tracing/Simple_Neurite_Tracer.java
+++ b/src/main/java/tracing/Simple_Neurite_Tracer.java
@@ -34,6 +34,7 @@ import ij.ImageStack;
 import ij.Macro;
 import ij.gui.GUI;
 import ij.gui.GenericDialog;
+import ij.gui.Overlay;
 import ij.gui.YesNoCancelDialog;
 import ij.measure.Calibration;
 import ij.plugin.PlugIn;
@@ -330,7 +331,9 @@ public class Simple_Neurite_Tracer extends SimpleNeuriteTracer
 				}
 			}
 
+			final Overlay currentImageOverlay = currentImage.getOverlay();
 			initialize(currentImage);
+			xy.setOverlay(currentImageOverlay);
 
 			xy_tracer_canvas = (InteractiveTracerCanvas)xy_canvas;
 			xz_tracer_canvas = (InteractiveTracerCanvas)xz_canvas;


### PR DESCRIPTION
This addresses:
- #12 
- #9,  namely ESWC import and  the ability to export paths as ROIs
- On exit, XZ/ZY images are only discarded if they have not been modified during the session
- Several GUI tweaks and improvements that make the plugin more usable on small screens:
  - Visibility of tracing panes can be toggled at will, and brought together via a "Arrange panes" command
  - Most commands will now work when a pane has been closed
  - Footprint of Path list window has been reduced