### PR TITLE
Release v3.1.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>sc.fiji</groupId>
 	<artifactId>Simple_Neurite_Tracer</artifactId>
-	<version>3.1.6-SNAPSHOT</version>
+	<version>3.1.7</version>
 
 	<name>Simple Neurite Tracer</name>
 	<description>The ImageJ framework for semi-automated tracing of neurons and other tube-like structures.</description>

--- a/src/main/java/tracing/ShollAnalysisDialog.java
+++ b/src/main/java/tracing/ShollAnalysisDialog.java
@@ -766,7 +766,7 @@ public class ShollAnalysisDialog extends Dialog implements WindowListener, Actio
 			} else {
 				final XYBarRenderer barRenderer = new XYBarRenderer();
 				barRenderer.setShadowVisible(false);
-				barRenderer.setGradientPaintTransformer(null);
+				//barRenderer.setGradientPaintTransformer(null);
 				barRenderer.setDrawBarOutline(false);
 				barRenderer.setBarPainter(new StandardXYBarPainter());
 				renderer = barRenderer;


### PR DESCRIPTION
This is a hot fix for the issue reported at http://forum.imagej.net/t/issues-running-sholl-analysis-on-simple-neurite-tracer/8957/4. Also, notice that I'm not updating the scijava-pom to its latest version: The rewrite of Simple Neurite Tracer will be released soon, and it is already using it.