### PR TITLE
add multiple_mesh_intersection notebook and graph diameter demo

### DIFF
--- a/src/main/resources/script_templates/Neuroanatomy/Analysis/Tree_Diameter.py
+++ b/src/main/resources/script_templates/Neuroanatomy/Analysis/Tree_Diameter.py
@@ -1,0 +1,123 @@
+"""
+file:       Tree_Diameter.py
+author:     Tiago Ferreira, Cameron Arshadi
+version:    20190210
+info:       A Jython demo which computes the diameter (graph theory) of a traced compartment
+            fetched from the MouseLight database.
+"""
+
+import time
+
+from tracing import Tree
+from tracing.io import MouseLightLoader
+from tracing.viewer import OBJMesh, Viewer3D
+from tracing.viewer.Viewer3D import ViewMode
+from tracing.analysis.graph import GraphUtils
+
+from org.jgrapht import GraphTests, Graphs
+from org.jgrapht import GraphPath
+from org.jgrapht.alg.shortestpath import DijkstraShortestPath
+
+
+def getGraphTips(graph):
+    """Return all terminal nodes (out-degree 0) of the graph."""
+    
+    return [node for node in graph.vertexSet() if graph.outDegreeOf(node) == 0]
+
+
+def distanceToRoot(graph, n):
+    """Return graph geodesic distance from node n to tree root."""
+    
+    distance = 0
+    if n.parent == -1:
+        return 0
+    while n.parent != -1:
+        pred = Graphs.predecessorListOf(graph, n)[0]
+        incoming_edge = [edge for edge in graph.incomingEdgesOf(n)][0]
+        weight = graph.getEdgeWeight(incoming_edge)
+        distance += weight
+        n = pred
+        
+    return distance
+
+
+def getTreeDiameter(graph):
+    """Return graph diameter, which for rooted directed trees
+    is the longest shortest path between the root and any terminal node."""
+    
+    tips = getGraphTips(graph)
+    max_dist = 0
+    for tip in tips:
+        dist = distanceToRoot(graph, tip)
+        if dist > max_dist:
+            max_dist = dist
+            
+    return max_dist
+
+
+def run():
+
+    # Fetch a neuron from the MouseLight database.
+    loader = MouseLightLoader("AA0100")
+
+    # Get the SWCPoint representation of each node,
+    # which contains all attributes of a single
+    # line in an SWC file.
+    nodes = loader.getNodes("axon")
+
+    # Build a jgrapht Graph object from the nodes
+    # and assign edge weights. Note that the
+    # default edge weight is euclidean distance
+    # between adjacent nodes.
+    graph = GraphUtils.createGraph(nodes, True)
+
+    # The root of the tree is the singular node with in-degree 0.
+    root = [node for node in graph.vertexSet() if graph.inDegreeOf(node) == 0][0]
+
+    # Tree diameter using parent pointers.
+    t0 = time.time()
+    tips = getGraphTips(graph)
+    print(getTreeDiameter(graph))
+    t1 = time.time()
+    print(t1-t0)
+
+    # Tree diameter using Dijkstra, which allows us
+    # to easily get the nodes along the path, albeit
+    # more slowly. Note that the above approach using
+    # parent pointers could be trivially modified to
+    # produce the nodes of the path.
+    t0 = time.time()
+    max_dist = 0
+    grapht_path = None
+    for tip in tips:
+        dsp = DijkstraShortestPath(graph)
+        dist = dsp.getPathWeight(root, tip)
+        if dist > max_dist:
+            max_dist = dist
+            grapht_path = dsp.getPath(root, tip)
+
+    print(max_dist)
+    t1 = time.time()
+    print(t1-t0)
+
+    # Visualize the longest path with Viewer3D
+    viewer = Viewer3D()
+
+    # Viewer3D accepts a tracing.Tree
+    snt_tree_input_nodes = Tree(nodes, "input nodes")
+    snt_tree_input_nodes.setColor("cyan")
+    viewer.add(snt_tree_input_nodes)
+
+    # Convert longest path to tracing.Tree
+    snt_tree_shortest_path = Tree(grapht_path.getVertexList(), "Dijkstra Shortest Path")
+    snt_tree_shortest_path.setColor("orange")
+
+    # Translate the path of the tree diameter to avoid color overlap
+    # with underlying path.
+    snt_tree_shortest_path.translate(30,30,30)
+    viewer.add(snt_tree_shortest_path)
+
+    viewer.show()
+
+
+run()

--- a/src/main/resources/script_templates/Neuroanatomy/pyimagej/notebooks/multiple_mesh_intersection.ipynb
+++ b/src/main/resources/script_templates/Neuroanatomy/pyimagej/notebooks/multiple_mesh_intersection.ipynb
@@ -1,0 +1,233 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook demonstrates how to find the convex hulls of two distinct traced dendritic trees,  \n",
+    "and to find the convex hulls that represent the spatial intersection and union of the two hulls.  \n",
+    "The volumes of the resulting meshes are used to calculate the Jaccard similarity coefficient, defined as follows:\n",
+    "<img src=\"https://wikimedia.org/api/rest_v1/media/math/render/svg/eaef5aa86949f49e7dc6b9c8c3dd8b233332c9e7\">\n",
+    "\n",
+    "Requirements:\n",
+    "- pyimagej\n",
+    "- trimesh (+ Blender backend for boolean operations)\n",
+    "  - see https://github.com/mikedh/trimesh/blob/master/trimesh/interfaces/blender.py for the expected locations of the Blender       executable\n",
+    "- numpy\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import imagej\n",
+    "import numpy as np\n",
+    "from trimesh import PointCloud\n",
+    "from trimesh.boolean import intersection\n",
+    "from trimesh.boolean import union"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Added 390 JARs to the Java classpath.\n"
+     ]
+    }
+   ],
+   "source": [
+    "\"\"\"Replace with path to your local ImageJ or Fiji installation.\n",
+    "This can be replaced with ij = imagej.init('sc.fiji:fiji')\n",
+    "once the scijava branch is merged to master.\"\"\"\n",
+    "\n",
+    "ij = imagej.init(r'/path/to/your/Fiji.app', headless=False)\n",
+    "from jnius import autoclass, cast"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Import relevant Java classes.\n",
+    "PointInImage = autoclass('tracing.util.PointInImage')\n",
+    "MouseLightLoader = autoclass('tracing.io.MouseLightLoader')\n",
+    "Tree = autoclass('tracing.Tree')\n",
+    "MultiTreeColorMapper = autoclass('tracing.analysis.MultiTreeColorMapper')\n",
+    "Color = autoclass('org.scijava.util.Colors')\n",
+    "ColorTables = autoclass(\"net.imagej.display.ColorTables\")\n",
+    "Viewer3D = autoclass('tracing.viewer.Viewer3D')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def fetch_reconstruction(id):\n",
+    "    \"\"\"Return tracing.Tree object of the given SWC identifier,\n",
+    "    if it exists in the MouseLight database.\"\"\"\n",
+    "    \n",
+    "    # Get loader for specified id.\n",
+    "    loader = MouseLightLoader(id)\n",
+    "    \n",
+    "    if not loader.isDatabaseAvailable():\n",
+    "        print(\"Could not connect to ML database\", \"Error\")\n",
+    "        return\n",
+    "    \n",
+    "    if not loader.idExists():\n",
+    "        print(\"Somewhow the specified id was not found\", \"Error\")\n",
+    "        return\n",
+    "    \n",
+    "    # Get tracing.Tree object representing the dendrites,\n",
+    "    # setting color to None.\n",
+    "    tree = loader.getTree('dendrites', None)\n",
+    "    \n",
+    "    return tree"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_node_coordinates(tree):\n",
+    "    \"\"\"Return a 2D numpy array of node\n",
+    "    x,y,z coordinates for all nodes of the given \n",
+    "    tracing.Tree\"\"\"\n",
+    "    \n",
+    "    # Get nodes as Java collection of PointInImage objects.\n",
+    "    points = tree.getPoints()\n",
+    "    \n",
+    "    # Get x,y,z coordinates from PointInImage objects.\n",
+    "    points_iterator = points.iterator()\n",
+    "    points_list = []\n",
+    "    while points_iterator.hasNext():\n",
+    "        p = points_iterator.next()\n",
+    "        points_list.append([p.x, p.y, p.z])\n",
+    "\n",
+    "    return np.asarray(points_list)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def run():\n",
+    "    \n",
+    "    # Two cells from Primary Motor Area, layer 5.\n",
+    "    # Their dendrites exhibit a high degree of spatial overlap.\n",
+    "    neuron_ids = [\"AA0133\", \"AA0134\"]\n",
+    "    trees = []\n",
+    "    meshes = []\n",
+    "\n",
+    "    for id in neuron_ids:\n",
+    "        # Get dendrite reconstruction from MouseLight database.\n",
+    "        tree = fetch_reconstruction(id)\n",
+    "        if tree is None:\n",
+    "            print(\"{} not found in database, exiting.\".format(id))\n",
+    "            return\n",
+    "        \n",
+    "        tree.setLabel(id)\n",
+    "        trees.append(tree)\n",
+    "        \n",
+    "        # Find the convex hull of the tracing with trimesh.\n",
+    "        tree_points = get_node_coordinates(tree)\n",
+    "        tree_cloud = PointCloud(tree_points)\n",
+    "        tree_hull = tree_cloud.convex_hull\n",
+    "        meshes.append(tree_hull)\n",
+    "    \n",
+    "    # Get spatial intersection of both hulls as \n",
+    "    # another convex hull.\n",
+    "    intersection_hull = intersection(meshes, engine='blender')\n",
+    "    if len(intersection_hull.vertices) == 0:\n",
+    "        print(\"No spatial overlap found, exiting.\")\n",
+    "        return\n",
+    "    \n",
+    "    # Compute the union hull of both hulls.\n",
+    "    union_hull = union(meshes, engine='blender')\n",
+    "    \n",
+    "    # Calculate the Jaccard similarity.\n",
+    "    print(\"The Jaccard similarity is {}\".format((intersection_hull.volume/union_hull.volume)))\n",
+    "    \n",
+    "    # Make a list of the outer vertices of the intersection hull\n",
+    "    # as PointInImage objects to pass to Viewer3D for rendering.\n",
+    "    verts = intersection_hull.vertices\n",
+    "    verts_list = []\n",
+    "    for v in verts:\n",
+    "        verts_list.append(PointInImage(v[0], v[1], v[2]))\n",
+    "    # Convert to Java collection using pyimagej.\n",
+    "    verts_java = ij.py.to_java(verts_list)\n",
+    "    \n",
+    "    viewer = Viewer3D()\n",
+    "    for t in trees:\n",
+    "        viewer.add(t)\n",
+    "    \n",
+    "    # Tree color in the viewer may be set using the neuron id string.\n",
+    "    colors = ij.py.to_java(neuron_ids)\n",
+    "    viewer.colorCode(colors, MultiTreeColorMapper.ID, ColorTables.ICE)\n",
+    "    # Pass the vertices of the intersection hull to render as a Delaunay surface.\n",
+    "    viewer.addSurface(verts_java, Color.YELLOW, 50)\n",
+    "    viewer.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING 2019-03-31 20:07:28,691: face_normals didn't match triangles, ignoring!\n",
+      "WARNING 2019-03-31 20:07:29,554: face_normals didn't match triangles, ignoring!\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The Jaccard similarity is 0.5057671897938841\n"
+     ]
+    }
+   ],
+   "source": [
+    "run()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "pyimagej jupyter env",
+   "language": "python",
+   "name": "pyimagej_notebook_env"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This commit adds an IPython notebook which demonstrates the calculation and rendering of meshes that result from spatial boolean operations, such as intersection and union, between two meshes. 

This may be useful, for example, to quantify a rough estimate of the amount of spatial overlap between two distinct dendritic trees.

Requirements:
-pyimagej
-trimesh + Blender
-numpy

Tested on Windows 10 64-bit