### PR TITLE
Add a fix for the termination condition of GraphUtils.firstRelevantAncestor()

### DIFF
--- a/src/main/java/sc/fiji/snt/analysis/graph/GraphUtils.java
+++ b/src/main/java/sc/fiji/snt/analysis/graph/GraphUtils.java
@@ -173,7 +173,7 @@ public class GraphUtils {
 				parent = Graphs.predecessorListOf(graph, node).get(0);
 				final double edgeWeight = graph.getEdge(parent, node).getWeight();
 				pathWeight += edgeWeight;
-				if (graph.degreeOf(parent) != 2) {
+				if (graph.inDegreeOf(parent) == 0 || graph.outDegreeOf(parent) > 1) {
 					return new SimplifiedVertex(parent, pathWeight);
 				}
 				node = parent;


### PR DESCRIPTION
This PR proposes a fix regarding an oversight (on my part) for the termination condition of GraphUtils.firstRelevantAncestor(). The original termination condition fails if the root node of the graph happens to be a branch point of degree == 2. Here is a demonstration of the issue. The following hypothetical tree has the root node at the top with two children. 
![bugdemo1](https://user-images.githubusercontent.com/44130022/72310916-06a5c700-3651-11ea-96b3-706154bca5ca.png)
Running GraphUtils.getSimplifiedGraph() on this tree will result in the following when shown in the Dendrogram viewer:
![bugdemo2](https://user-images.githubusercontent.com/44130022/72310993-4a003580-3651-11ea-8b83-762858a0a33a.png)
Note how the root node is not connected to it's children (also note the node with ID 1 is obscured beneath the node with ID 2). The proposed fix modifies the GraphUtils.firstRelevantAncestor() function to terminate at either the root node (in-degree == 0) or any arbitrary branch point (out-degree > 1).
Here is the result of the proposed fix: 
![bugdemo3](https://user-images.githubusercontent.com/44130022/72311136-ba0ebb80-3651-11ea-8f28-0c8a848be1be.png)
The graph now has the correct connectivity and topology.
